### PR TITLE
Fix issue that caused players to start with 0 elo

### DIFF
--- a/data/data.js
+++ b/data/data.js
@@ -132,7 +132,7 @@ module.exports = {
     },
     getPlayerElo: function(id, category) {
         let playerRanked = getPlayerRankedData(id, category);
-        if (playerRanked !== null){
+        if (playerRanked !== null && playerRanked.elo !== 0 && playerRanked.matches > 0) {
             return playerRanked.elo;
         } else {
             changePlayerElo(id, category, true, 1000);


### PR DESCRIPTION
Fix issue that caused players to start with 0 elo after playing a normal game before a ranked game